### PR TITLE
Add version responder

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -136,6 +136,11 @@ Usage
         responders.wat:         { class: shirka.responders.wat.WatResponder }
         responders.9gag:        { class: shirka.responders.ninegag.NineGagResponder }
 
+        responders.version:
+            class: shirka.responders.VersionResponder
+            arguments:
+                - '%bot.name%'
+
         responders.remote:
             class: shirka.responders.remote.RemoteResponder
             arguments: 
@@ -184,6 +189,7 @@ Usage
                     - '@responders.status'
                     - '@responders.test.help'
                     - '@responders.test.whois'
+                    - '@responders.version'
                     
                 - '@flowdock.test'
             kwargs:

--- a/shirka/responders/__init__.py
+++ b/shirka/responders/__init__.py
@@ -53,3 +53,4 @@ from monitor import MonitorResponder
 from process import ProcessResponder
 from so import SoResponder
 from jira_responder import JiraResponder
+from version import VersionResponder

--- a/shirka/responders/version.py
+++ b/shirka/responders/version.py
@@ -1,0 +1,23 @@
+# vim: set fileencoding=utf-8 :
+
+from shirka.responders import Responder
+from shirka.consumers import BaseTestCase
+import subprocess
+
+
+class VersionResponder(Responder):
+    def __init__(self, bot_name):
+        self.bot_name = bot_name
+
+    def name(self):
+        return 'version'
+
+    def generate(self, request):
+        """
+        usage: version
+        return current bot version by getting the closest git tag
+        """
+
+        version = subprocess.check_output(["git", "describe", "--abbrev=0", "--tags"])
+
+        return "%s - V%s" % (self.bot_name, version)

--- a/shirka/responders/version.py
+++ b/shirka/responders/version.py
@@ -2,6 +2,7 @@
 
 from shirka.responders import Responder
 from shirka.consumers import BaseTestCase
+from mocker import Mocker
 import subprocess
 
 
@@ -21,3 +22,24 @@ class VersionResponder(Responder):
         version = subprocess.check_output(["git", "describe", "--abbrev=0", "--tags"])
 
         return "%s - V%s" % (self.bot_name, version)
+
+
+class TestVersionResponder(BaseTestCase):
+    def setUp(self):
+        mocker = Mocker()
+        git_subprocess = mocker.replace("subprocess.check_output")
+        git_subprocess(["git", "describe", "--abbrev=0", "--tags"])
+        mocker.result("0.0.1")
+        mocker.replay()
+
+        self.responder = VersionResponder("shirka")
+
+    def test_support(self):
+        self.assertTrue(self.responder.support(self.create_request("version")))
+        self.assertFalse(self.responder.support(self.create_request("fuu")))
+
+    def test_valid(self):
+        self.assertEquals("shirka - V0.0.1", self.generate("version"))
+
+    def test_on_start(self):
+        self.assertFalse(self.responder.on_start(False))


### PR DESCRIPTION
This responder display bot version based on closest git tag, but the version defined in the setup file doesn't match the git tag, perhaps it's possible to use the same system in the setup file ?
I've seen post about fetching current package version on stackoverflow: http://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package
but as the value doesn't match/is lower than the git tag, I fetch it through git.
